### PR TITLE
Optimize 2nd task [Wait, that's illegal!]

### DIFF
--- a/Candy/Candy.cpp
+++ b/Candy/Candy.cpp
@@ -1,32 +1,24 @@
 #include <iostream>
 #include <string>
-#include <vector>
 #include <fstream>
 #include <filesystem>
 #include "../_include/getExePath.h"
 
+using namespace std;
+
 int main() {
-	std::filesystem::path inputDir = std::filesystem::path(getExePath()) / "Input" / "Candy";
-	for (auto& file : std::filesystem::directory_iterator(inputDir)) {
-		std::vector<std::string> shouts{};
-
-		std::ifstream input(file);
-		while (true) {
-			std::string tmp;
+	filesystem::path inputDir = filesystem::path(getExePath()) / "Input" / "Candy";
+	for (auto& file : filesystem::directory_iterator(inputDir)) {		
+		uint64_t currentPosition = 0, currentBit = 0;
+		ifstream input(file);
+		while (!input.eof()) {
+			string tmp;
 			input >> tmp;
-			shouts.emplace_back(tmp);
-			if (input.eof()) break;
+			if (tmp == "odd")
+				currentPosition |= 1ULL << currentBit;
+			++currentBit;
 		}
 
-		size_t currentPosition = 1; // We end at one.
-
-		// We are simply gonna reverse the process
-		for (auto i = shouts.rbegin(); i < shouts.rend(); ++i) {
-			if (*i == "odd") // If odd is shouted, our current position is guaranteed to double
-				currentPosition += currentPosition;
-			else if (*i == "even" && currentPosition > 0) // If even is shouted and we aren't in the first spot, the people in front of us is doubled.
-				currentPosition += currentPosition - 1;
-		}
-		std::cout << currentPosition << std::endl;
+		cout << ++currentPosition << endl;
 	}
 }

--- a/Candy/Candy.cpp
+++ b/Candy/Candy.cpp
@@ -6,9 +6,11 @@
 
 using namespace std;
 
+// Read a brief explaination at https://github.com/LumpBloom7/MCC2019/pull/2
+
 int main() {
 	filesystem::path inputDir = filesystem::path(getExePath()) / "Input" / "Candy";
-	for (auto& file : filesystem::directory_iterator(inputDir)) {		
+	for (auto& file : filesystem::directory_iterator(inputDir)) {
 		uint64_t currentPosition = 0, currentBit = 0;
 		ifstream input(file);
 		while (!input.eof()) {


### PR DESCRIPTION
Small explanation of the idea:
Let's think that `even` is 0 and `odd` is 1. And they're both bits.
So let's create the number from them.
Then let's consider the simplest examples:
```
*what we have*   *bits*       *reversed*      *number*      *answer*
even               0              0              0             1
odd                1              1              1             2
even even          00             0              0             1
odd even           10             1              1             2
odd odd            11             11             3             4
even even even     000            0              0             1
even even odd      001            100            4             5
even odd even      010            10             2             3
even odd odd       011            110            6             7
odd even even      100            1              1             2
```

Lul, you've almost got the right answer. Just reverse bits and increment the resulting number and you'll get the right answer.

### So, the main idea of my solution:
- We can append bits when reading shouts: if *i*-th shout is `odd`, "turn on" *i*-th bit in the current position number (if `even` - skip it)
- At the end (when we read all shouts) increment the result.